### PR TITLE
Update publiccode.yaml

### DIFF
--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -1,6 +1,6 @@
 publiccodeYmlVersion: "0.2"
 # Instructies: https://github.com/OpenCatalogi/OpenCatalogiBundle/blob/main/docs/Publiccode.md
-name: WebformulierenVerwerker
+name: MijnZaakNotificaties
 url: "https://github.com/Sudwest-Fryslan/MijnZaakNotificaties.git"
 softwareVersion: "1.20.9"    # Optional
 releaseDate: 2023-11-21


### PR DESCRIPTION
De naam is WebFormulierenVerwerker, waardoor deze onder een verkeede naam in OpenCatalogi terechtkomt. Ik heb een verzoek tot wijziging gedaan.